### PR TITLE
Änderungen, die sich aus der MV automatisch ergaben

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -182,5 +182,6 @@ folgende Möglichkeiten dieses zu sanktionieren:
   Verfolgung bleibt von diesen Regelungen unberührt.
   - Der Vorstand definiert sich durch die aktuell gültige Satzung.
   - Das Plenum definiert sich durch die AG Plenum gerade neu. [TODO!]
-  - Die Keyholder definieren sich durch die AG Keyholder gerade neu. [TODO!]
+  - Keyholder sind alle Mitglieder des MuCCC, die eine Schließberechtigung 
+  für die Räume des Clubs besitzen
   

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-﻿# Konkreter Vorschlag der AG Regeln
+﻿# Verhaltensregeln im CCC München
 
 ## Vorwort
 


### PR DESCRIPTION
- Durch Beschluss der MV 2018 ist der Regelsatz gültig und daher kein "Entwurf" mehr.

- Die durch Beschluss eingeführte Neuregelung der Schlüsselvergabe impliziert die Definition der Keyholder
