### PR TITLE
Ergänzung entsprechend plenumsbeschuss 2019-03

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -197,9 +197,11 @@ die Plenen selbst.
   einberufen werden.
   - Plenumspunkte sollen immer mind. 72h vor Beginn des Plenums auf der 
   Plenumswikiseite eingetragen sein.
-  - Abstimmvorschläge (nicht im Wortlaut, sondern im Topic) muessen immer
-  mind. 72h vor Beginn des Plenums auf der Plenumswikiseite eingetragen sein.
-
+  - Abstimmvorschläge (nach dem Muster "eine Abstimmung darüber wie mit 
+  xyz verfahren werden muss") müssen immer mind. 72h vor Beginn des Plenums 
+  auf der Plenumswikiseite eingetragen sein. Der konkrete Wortlaut der 
+  Abstimmvorschläge kann im Plenum erarbeitet werden.
+  
 ### Anmerkungen zu Teil 4:
   - Dieser Teil befindet sich in einer sehr frühen Entwurfsfassung und sollte
   in den kommenden Monaten stetig erweitert werden.

--- a/readme.md
+++ b/readme.md
@@ -197,8 +197,8 @@ die Plenen selbst.
   einberufen werden.
   - Plenumspunkte sollen immer mind. 72h vor Beginn des Plenums auf der 
   Plenumswikiseite eingetragen sein.
-  - Abstimmvorschläge muessen immer mind. 72h vor Beginn des Plenums auf der 
-  Plenumswikiseite eingetragen sein.
+  - Abstimmvorschläge (nicht im Wortlaut, sondern im Topic) muessen immer
+  mind. 72h vor Beginn des Plenums auf der Plenumswikiseite eingetragen sein.
 
 ### Anmerkungen zu Teil 4:
   - Dieser Teil befindet sich in einer sehr frühen Entwurfsfassung und sollte


### PR DESCRIPTION
Vollständigere Wiedergabe der im Plenum 2019-03 beschlossenen Regel bzgl der Einrechungsfristen von Abstimmungsvorlagen um Bezug auf Unveränderbarkeit des Wortlauts
vgl [Plenumsprotokol 2019-03 ](https://wiki.muc.ccc.de/intern:plenum-2019-03#einfuehrung_neuer_plenumsregeln)